### PR TITLE
chore: remove Share Files

### DIFF
--- a/docs/internal_open_source_tooling.md
+++ b/docs/internal_open_source_tooling.md
@@ -20,7 +20,6 @@
 - Scan files - https://github.com/cds-snc/scan-files
 - Scan websites - https://github.com/cds-snc/scan-websites
 - Share secrets securely - https://github.com/cds-snc/secret
-- Share files securely - https://github.com/cds-snc/share-files-securely
 
 ## GitHub
 


### PR DESCRIPTION
# Summary
Update the docs to remove Share Files as
the service is being shutdown.

# Related
- https://github.com/cds-snc/share-files-securely/pull/28